### PR TITLE
Improvement: Add Auto-Configuration for Thread Usage in MediaProcessor #5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,5 +11,5 @@ IndentCaseLabels: true
 SpaceBeforeParens: ControlStatements
 SpacesInParentheses: false
 SpacesInConditionalStatement: false
-ReflowComments: false
+ReflowComments: true
 ...

--- a/MediaProcessor/CMakeLists.txt
+++ b/MediaProcessor/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(MediaProcessor
     src/VideoProcessor.cpp
     src/Utils.cpp
     src/CommandBuilder.cpp
+    src/HardwareUtils.cpp
 )
 
 # Threads is required

--- a/MediaProcessor/src/AudioProcessor.cpp
+++ b/MediaProcessor/src/AudioProcessor.cpp
@@ -225,13 +225,13 @@ bool AudioProcessor::mergeChunks() {
     for (const auto& chunkPath : m_processedChunkPaths) {
         cmd.addFlag("-i", chunkPath.string());
     }
-  
+
     // If there's more then one processed chunk
     if (static_cast<int>(m_processedChunkPaths.size()) >= 2) {
         cmd.addFlag("-filter_complex", buildFilterComplex());
         cmd.addFlag("-map", "[outa]");
     }
-    
+
     cmd.addFlag("-c:a", "pcm_s16le");
     cmd.addFlag("-ar", "48000");
     cmd.addArgument(m_outputAudioPath.string());

--- a/MediaProcessor/src/AudioProcessor.h
+++ b/MediaProcessor/src/AudioProcessor.h
@@ -6,7 +6,6 @@
 
 namespace MediaProcessor {
 
-constexpr int DEFAULT_NUM_CHUNKS = 6;
 constexpr double DEFAULT_OVERLAP_DURATION = 0.5;
 
 class AudioProcessor {
@@ -34,6 +33,7 @@ class AudioProcessor {
     bool extractAudio();
     bool chunkAudio();
     bool filterChunks();
+    std::string buildFilterComplex() const;
     bool mergeChunks();
 
     // Moved from Utils, specific to audio processing

--- a/MediaProcessor/src/ConfigManager.cpp
+++ b/MediaProcessor/src/ConfigManager.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "HardwareUtils.h"
+
 namespace MediaProcessor {
 
 ConfigManager &ConfigManager::getInstance() {
@@ -27,6 +29,25 @@ std::string ConfigManager::getDeepFilterPath() const {
 
 std::string ConfigManager::getFFmpegPath() const {
     return m_config["ffmpeg_path"].get<std::string>();
+}
+
+unsigned int ConfigManager::getOptimalThreadCount() {
+    unsigned int configNumThreads = getNumThreadsValue();
+    unsigned int hardwareNumThreads = HardwareUtils::getHardwareThreadCount();
+
+    return determineNumThreads(configNumThreads, hardwareNumThreads);
+}
+
+unsigned int ConfigManager::getNumThreadsValue() {
+    return (m_config["limit_thread"].get<bool>())
+               ? m_config["max_thread"].get<unsigned int>()
+               : 0;
+}
+
+unsigned int ConfigManager::determineNumThreads(unsigned int configNumThreads,
+                                                unsigned int hardwareNumThreads) {
+    return (configNumThreads >= 1 && configNumThreads <= hardwareNumThreads) ? configNumThreads
+                                                                             : hardwareNumThreads;
 }
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/ConfigManager.cpp
+++ b/MediaProcessor/src/ConfigManager.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "HardwareUtils.h"
+#include "Utils.h"
 
 namespace MediaProcessor {
 
@@ -39,15 +40,14 @@ unsigned int ConfigManager::getOptimalThreadCount() {
 }
 
 unsigned int ConfigManager::getNumThreadsValue() {
-    return (m_config["limit_thread"].get<bool>())
-               ? m_config["max_thread"].get<unsigned int>()
+    return (m_config["use_thread_cap"].get<bool>())
+               ? m_config["max_threads_if_capped"].get<unsigned int>()
                : 0;
 }
 
 unsigned int ConfigManager::determineNumThreads(unsigned int configNumThreads,
                                                 unsigned int hardwareNumThreads) {
-    return (configNumThreads >= 1 && configNumThreads <= hardwareNumThreads) ? configNumThreads
-                                                                             : hardwareNumThreads;
+    return Utils::isWithinRange(configNumThreads, 1, hardwareNumThreads) ? configNumThreads
+                                                                         : hardwareNumThreads;
 }
-
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/ConfigManager.h
+++ b/MediaProcessor/src/ConfigManager.h
@@ -13,8 +13,12 @@ class ConfigManager {
     bool loadConfig(const std::string &configFilePath);
     std::string getDeepFilterPath() const;
     std::string getFFmpegPath() const;
+    unsigned int getOptimalThreadCount();
 
    private:
+    unsigned int getNumThreadsValue();
+    unsigned int determineNumThreads(unsigned int configNumThreads, unsigned int hardwareNumThreads);
+
     ConfigManager() = default;
     nlohmann::json m_config;
 };

--- a/MediaProcessor/src/ConfigManager.h
+++ b/MediaProcessor/src/ConfigManager.h
@@ -19,7 +19,8 @@ class ConfigManager {
 
    private:
     unsigned int getNumThreadsValue();
-    unsigned int determineNumThreads(unsigned int configNumThreads, unsigned int hardwareNumThreads);
+    unsigned int determineNumThreads(unsigned int configNumThreads,
+                                     unsigned int hardwareNumThreads);
 
     ConfigManager() = default;
     nlohmann::json m_config;

--- a/MediaProcessor/src/HardwareUtils.cpp
+++ b/MediaProcessor/src/HardwareUtils.cpp
@@ -1,0 +1,20 @@
+#include "HardwareUtils.h"
+
+#include <thread>
+
+namespace MediaProcessor::HardwareUtils{
+
+unsigned int getHardwareThreadCount() {
+    /*
+        * If the value is not well-defined or not computable, hardware_concurrency() may return 0.
+        * In that case, we'll fall back to DEFAULT_NUM_CHUNKS.
+        * We subtract 2 from the available hardware threads as a safety margin to avoid overloading the system.
+        */
+    unsigned int hardwareThreadCount = std::thread::hardware_concurrency();
+    if (hardwareThreadCount > 0) {
+        return (hardwareThreadCount > 2) ? (hardwareThreadCount - 2) : 1;
+    }
+    return DEFAULT_NUM_THREADS;
+}
+
+}  // namespace MediaProcessor

--- a/MediaProcessor/src/HardwareUtils.cpp
+++ b/MediaProcessor/src/HardwareUtils.cpp
@@ -2,14 +2,15 @@
 
 #include <thread>
 
-namespace MediaProcessor::HardwareUtils{
+namespace MediaProcessor::HardwareUtils {
 
 unsigned int getHardwareThreadCount() {
     /*
-        * If the value is not well-defined or not computable, hardware_concurrency() may return 0.
-        * In that case, we'll fall back to DEFAULT_NUM_CHUNKS.
-        * We subtract 2 from the available hardware threads as a safety margin to avoid overloading the system.
-        */
+     * If the value is not well-defined or not computable, hardware_concurrency() may return 0.
+     * In that case, we'll fall back to DEFAULT_NUM_CHUNKS.
+     * We subtract 2 from the available hardware threads as a safety margin to avoid overloading the
+     * system.
+     */
     unsigned int hardwareThreadCount = std::thread::hardware_concurrency();
     if (hardwareThreadCount > 0) {
         return (hardwareThreadCount > 2) ? (hardwareThreadCount - 2) : 1;
@@ -17,4 +18,4 @@ unsigned int getHardwareThreadCount() {
     return DEFAULT_NUM_THREADS;
 }
 
-}  // namespace MediaProcessor
+}  // namespace MediaProcessor::HardwareUtils

--- a/MediaProcessor/src/HardwareUtils.h
+++ b/MediaProcessor/src/HardwareUtils.h
@@ -6,6 +6,6 @@ namespace MediaProcessor::HardwareUtils {
 constexpr unsigned int DEFAULT_NUM_THREADS = 6;
 unsigned int getHardwareThreadCount();
 
-}  // namespace MediaProcessor
+}  // namespace MediaProcessor::HardwareUtils
 
 #endif  // HARDWAREUTILS_H

--- a/MediaProcessor/src/HardwareUtils.h
+++ b/MediaProcessor/src/HardwareUtils.h
@@ -1,0 +1,11 @@
+#ifndef HARDWAREUTILS_H
+#define HARDWAREUTILS_H
+
+namespace MediaProcessor::HardwareUtils {
+
+constexpr unsigned int DEFAULT_NUM_THREADS = 6;
+unsigned int getHardwareThreadCount();
+
+}  // namespace MediaProcessor
+
+#endif  // HARDWAREUTILS_H

--- a/MediaProcessor/src/Utils.cpp
+++ b/MediaProcessor/src/Utils.cpp
@@ -78,6 +78,10 @@ bool containsWhitespace(const std::string &str) {
     return str.find(' ') != std::string::npos;
 }
 
+bool isWithinRange(unsigned int value, unsigned int lowerBound, unsigned int upperBound) {
+    return value >= lowerBound && value <= upperBound;
+}
+
 std::string trimTrailingSpace(const std::string &str) {
     if (str.empty() || str.back() != ' ') {
         return str;

--- a/MediaProcessor/src/Utils.h
+++ b/MediaProcessor/src/Utils.h
@@ -14,6 +14,7 @@ std::pair<fs::path, fs::path> prepareOutputPaths(const fs::path &videoPath);
 bool ensureDirectoryExists(const fs::path &path);
 bool removeFileIfExists(const fs::path &filePath);
 bool containsWhitespace(const std::string &str);
+bool isWithinRange(unsigned int value, unsigned int lowerBound, unsigned int upperBound);
 std::string trimTrailingSpace(const std::string &str);
 
 }  // namespace MediaProcessor::Utils

--- a/config.json
+++ b/config.json
@@ -2,5 +2,7 @@
     "deep_filter_path": "MediaProcessor/res/deep-filter-0.5.6-x86_64-unknown-linux-musl",
     "downloads_dir": "downloads",
     "ffmpeg_path": "/usr/bin/ffmpeg",
-    "upload_folder": "uploads" 
+    "upload_folder": "uploads",
+    "limit_thread": false,
+    "max_thread": 6
 }

--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
     "downloads_dir": "downloads",
     "ffmpeg_path": "/usr/bin/ffmpeg",
     "upload_folder": "uploads",
-    "limit_thread": false,
-    "max_thread": 6
+    "use_thread_cap": false,
+    "max_threads_if_capped": 6
 }


### PR DESCRIPTION
#5 

### Updates and Enhancements
- **Added `determineNumChunks()` function**  
  A new function in the `AudioProcessor` class is responsible for dynamically determining the number of chunks (threads) based on system hardware or configuration.
1. use number of chunks given in the config file if within range i.e. [1, total_threads].
1. else use total_threads - 2 if total_threads > 2 else use single thread
1. else use Deafult number of chunks if can't determine number of threads.

- **Updated `AudioProcessor` constructor**  
  The constructor calls the `determineNumChunks()` funtion to determine the dynamic number of chunks.

- **Modified `ConfigManager`**  
  The `ConfigManager` class now supports the configuration of `num_chunks` in the configuration file.

- **Updated the configuration file**  
  The configuration file has been updated to include the `num_chunks` setting, allowing users to adjust the number of chunks (threads) for processing.