### PR TITLE
Refactor: Update core for standardized filepaths and command building 

### DIFF
--- a/MediaProcessor/src/AudioProcessor.h
+++ b/MediaProcessor/src/AudioProcessor.h
@@ -1,8 +1,11 @@
 #ifndef AUDIOPROCESSOR_H
 #define AUDIOPROCESSOR_H
 
+#include <filesystem>
 #include <string>
 #include <vector>
+
+namespace fs = std::filesystem;
 
 namespace MediaProcessor {
 
@@ -11,22 +14,22 @@ constexpr double DEFAULT_OVERLAP_DURATION = 0.5;
 
 class AudioProcessor {
    public:
-    AudioProcessor(const std::string &inputVideoPath, const std::string &outputAudioPath);
+    AudioProcessor(const fs::path &inputVideoPath, const fs::path &outputAudioPath);
 
     bool isolateVocals();
 
    private:
-    std::string m_inputVideoPath;
-    std::string m_outputAudioPath;
+    fs::path m_inputVideoPath;
+    fs::path m_outputAudioPath;
 
     int m_numChunks;
     double m_overlapDuration;
 
-    std::string m_outputDir;
-    std::string m_chunksDir;
-    std::string m_processedChunksDir;
-    std::vector<std::string> m_chunkPaths;
-    std::vector<std::string> m_processedChunkPaths;
+    fs::path m_outputDir;
+    fs::path m_chunksDir;
+    fs::path m_processedChunksDir;
+    std::vector<fs::path> m_chunkPaths;
+    std::vector<fs::path> m_processedChunkPaths;
     std::vector<double> m_startTimes;
     std::vector<double> m_durations;
     double m_totalDuration;
@@ -36,7 +39,7 @@ class AudioProcessor {
     bool filterChunks();
     bool mergeChunks();
 
-    double getAudioDuration(const std::string &audioPath);
+    double getAudioDuration(const fs::path &audioPath);
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/CommandBuilder.cpp
+++ b/MediaProcessor/src/CommandBuilder.cpp
@@ -1,3 +1,4 @@
+// CommandBuilder.cpp
 #include "CommandBuilder.h"
 
 #include <sstream>
@@ -6,30 +7,30 @@
 
 namespace MediaProcessor {
 
-void CommandBuilder::addArgument(std::filesystem::path arg) {
-    m_arguments.push_back(std::move(arg).string());
+void CommandBuilder::addArgument(const std::string& arg) {
+    m_arguments.push_back(arg);
 }
 
-void CommandBuilder::addFlag(std::string flag) {
-    m_arguments.push_back(std::move(flag));
+void CommandBuilder::addFlag(const std::string& flag) {
+    m_arguments.push_back(flag);
 }
 
-void CommandBuilder::addFlag(std::string flag, std::string value) {
-    m_arguments.push_back(std::move(flag));
-    m_arguments.push_back(std::move(value));
+void CommandBuilder::addFlag(const std::string& flag, const std::string& value) {
+    m_arguments.push_back(flag);
+    m_arguments.push_back(value);
 }
 
 std::string CommandBuilder::build() const {
-    using MediaProcessor::Utils::trimTrailingSpace;
-
     std::ostringstream command;
-    for (const auto &arg : m_arguments) {
-        command << formatArgument(arg) << " ";
+    for (const auto& arg : m_arguments) {
+        command << formatArgument(arg) << ' ';
     }
-    return trimTrailingSpace(command.str());
+    std::string commandStr = command.str();
+
+    return Utils::trimTrailingSpace(commandStr);
 }
 
-std::string CommandBuilder::formatArgument(const std::string &arg) const {
+std::string CommandBuilder::formatArgument(const std::string& arg) const {
     using MediaProcessor::Utils::containsWhitespace;
 
     if (containsWhitespace(arg)) {

--- a/MediaProcessor/src/CommandBuilder.h
+++ b/MediaProcessor/src/CommandBuilder.h
@@ -1,7 +1,6 @@
 #ifndef COMMANDBUILDER_H
 #define COMMANDBUILDER_H
 
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -11,18 +10,15 @@ namespace MediaProcessor {
 
 class CommandBuilder : public ICommandBuilder {
    public:
-    virtual ~CommandBuilder() = default;
-
-    void addArgument(std::filesystem::path arg) override;
-    void addFlag(std::string flag) override;
-    void addFlag(std::string flag, std::string value) override;
-
+    void addArgument(const std::string& arg) override;
+    void addFlag(const std::string& flag) override;
+    void addFlag(const std::string& flag, const std::string& value) override;
     std::string build() const override;
 
-   protected:
-    std::string formatArgument(const std::string &arg) const;
-
+   private:
     std::vector<std::string> m_arguments;
+
+    std::string formatArgument(const std::string& arg) const;
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/ConfigManager.cpp
+++ b/MediaProcessor/src/ConfigManager.cpp
@@ -5,12 +5,12 @@
 
 namespace MediaProcessor {
 
-ConfigManager &ConfigManager::getInstance() {
+ConfigManager& ConfigManager::getInstance() {
     static ConfigManager instance;
     return instance;
 }
 
-bool ConfigManager::loadConfig(const std::string &configFilePath) {
+bool ConfigManager::loadConfig(const fs::path& configFilePath) {
     std::ifstream config_file(configFilePath);
     if (!config_file.is_open()) {
         std::cerr << "Error: Could not open " << configFilePath << std::endl;
@@ -21,11 +21,11 @@ bool ConfigManager::loadConfig(const std::string &configFilePath) {
     return true;
 }
 
-std::string ConfigManager::getDeepFilterPath() const {
+fs::path ConfigManager::getDeepFilterPath() const {
     return m_config["deep_filter_path"].get<std::string>();
 }
 
-std::string ConfigManager::getFFmpegPath() const {
+fs::path ConfigManager::getFFmpegPath() const {
     return m_config["ffmpeg_path"].get<std::string>();
 }
 

--- a/MediaProcessor/src/ConfigManager.h
+++ b/MediaProcessor/src/ConfigManager.h
@@ -1,18 +1,20 @@
 #ifndef CONFIGMANAGER_H
 #define CONFIGMANAGER_H
 
+#include <filesystem>
 #include <nlohmann/json.hpp>
 #include <string>
 
+namespace fs = std::filesystem;
 namespace MediaProcessor {
 
 class ConfigManager {
    public:
-    static ConfigManager &getInstance();
+    static ConfigManager& getInstance();
 
-    bool loadConfig(const std::string &configFilePath);
-    std::string getDeepFilterPath() const;
-    std::string getFFmpegPath() const;
+    bool loadConfig(const fs::path& configFilePath);
+    fs::path getDeepFilterPath() const;
+    fs::path getFFmpegPath() const;
 
    private:
     ConfigManager() = default;

--- a/MediaProcessor/src/ICommandBuilder.h
+++ b/MediaProcessor/src/ICommandBuilder.h
@@ -1,7 +1,6 @@
 #ifndef ICOMMANDBUILDER_H
 #define ICOMMANDBUILDER_H
 
-#include <filesystem>
 #include <string>
 
 namespace MediaProcessor {
@@ -15,9 +14,9 @@ class ICommandBuilder {
 
     virtual std::string build() const = 0;
 
-    virtual void addArgument(std::filesystem::path arg) = 0;
-    virtual void addFlag(std::string flag) = 0;
-    virtual void addFlag(std::string flag, std::string value) = 0;
+    virtual void addArgument(const std::string& arg) = 0;
+    virtual void addFlag(const std::string& flag) = 0;
+    virtual void addFlag(const std::string& flag, const std::string& value) = 0;
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/Utils.cpp
+++ b/MediaProcessor/src/Utils.cpp
@@ -36,22 +36,23 @@ bool runCommand(const std::string &command) {
     return true;
 }
 
-std::pair<std::string, std::string> prepareOutputPaths(const std::string &videoPath) {
+std::pair<std::filesystem::path, std::filesystem::path> prepareOutputPaths(
+    const std::filesystem::path &videoPath) {
     /*
      * Prepares and returns the output paths for the vocals and processed video files.
      */
 
-    std::filesystem::path videoFilePath(videoPath);
-    std::string baseFilename = videoFilePath.stem().string();
-    std::string outputDir = videoFilePath.parent_path().string();
+    std::string baseFilename = videoPath.stem().string();
 
-    std::string vocalsPath = outputDir + "/" + baseFilename + "_isolated_audio.wav";
-    std::string processedVideoPath = outputDir + "/" + baseFilename + "_processed_video.mp4";
+    std::filesystem::path outputDir = videoPath.parent_path();
+
+    std::filesystem::path vocalsPath = outputDir / (baseFilename + "_isolated_audio.wav");
+    std::filesystem::path processedVideoPath = outputDir / (baseFilename + "_processed_video.mp4");
 
     return {vocalsPath, processedVideoPath};
 }
 
-bool ensureDirectoryExists(const std::string &path) {
+bool ensureDirectoryExists(const std::filesystem::path &path) {
     /*
      * Ensures the specified directory exists by making the directory if necessary
      */
@@ -64,7 +65,7 @@ bool ensureDirectoryExists(const std::string &path) {
     return false;
 }
 
-bool removeFileIfExists(const std::string &filePath) {
+bool removeFileIfExists(const std::filesystem::path &filePath) {
     if (std::filesystem::exists(filePath)) {
         std::cout << "File already exists, removing it: " << filePath << std::endl;
         std::filesystem::remove(filePath);

--- a/MediaProcessor/src/Utils.h
+++ b/MediaProcessor/src/Utils.h
@@ -1,15 +1,18 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <filesystem>
 #include <string>
 #include <utility>
+
+namespace fs = std::filesystem;
 
 namespace MediaProcessor::Utils {
 
 bool runCommand(const std::string &command);
-std::pair<std::string, std::string> prepareOutputPaths(const std::string &videoPath);
-bool ensureDirectoryExists(const std::string &path);
-bool removeFileIfExists(const std::string &filePath);
+std::pair<fs::path, fs::path> prepareOutputPaths(const fs::path &videoPath);
+bool ensureDirectoryExists(const fs::path &path);
+bool removeFileIfExists(const fs::path &filePath);
 bool containsWhitespace(const std::string &str);
 std::string trimTrailingSpace(const std::string &str);
 

--- a/MediaProcessor/src/VideoProcessor.h
+++ b/MediaProcessor/src/VideoProcessor.h
@@ -1,22 +1,24 @@
 #ifndef VIDEOPROCESSOR_H
 #define VIDEOPROCESSOR_H
 
-#include <string>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 namespace MediaProcessor {
 
 class VideoProcessor {
    public:
-    VideoProcessor(const std::string &videoPath, const std::string &audioPath,
-                   const std::string &outputPath);
+    VideoProcessor(const fs::path &videoPath, const fs::path &audioPath,
+                   const fs::path &outputPath);
 
     bool mergeMedia();
 
    private:
-    std::string m_videoPath;
-    std::string m_audioPath;
-    std::string m_outputPath;
-    std::string m_ffmpegPath;
+    fs::path m_videoPath;
+    fs::path m_audioPath;
+    fs::path m_outputPath;
+    fs::path m_ffmpegPath;
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/main.cpp
+++ b/MediaProcessor/src/main.cpp
@@ -7,19 +7,21 @@
 #include "Utils.h"
 #include "VideoProcessor.h"
 
+namespace fs = std::filesystem;
+
 using namespace MediaProcessor;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     /*
-     * Main function to process a video file by isolating vocals and merging them back with the original media.
-     * This process removes music, sound effects and noise from media, without distorting the vocals.
-     * 
-     * How it works:
-     *   1) Load the configuration from "config.json".
-     *   2) Extract the audio from the video and isolate vocals using DeepFilterNet.
-     *   3) Chunk the audio, process it in parallel, and generate an isolated audio (vocals) track.
-     *   4) Merge the isolated audio track back with the original video to produce a processed video.
-     * 
+     * Main function to process a video file by isolating vocals and merging them back with the original video.
+     * Removes music, sound effects, and noise while retaining clear vocals.
+     *
+     * Workflow:
+     *   1. Load configuration from "config.json".
+     *   2. Extract and isolate vocals using DeepFilterNet.
+     *   3. Process the audio in chunks with parallel processing.
+     *   4. Merge the isolated vocals back with the original video to create the output.
+     *
      * Usage: <executable> <video_file_path>
      */
 
@@ -27,9 +29,9 @@ int main(int argc, char *argv[]) {
         std::cerr << "Usage: " << argv[0] << " <video_file_path>" << std::endl;
         return 1;
     }
-    std::string inputMediaPath = argv[1];
+    fs::path inputMediaPath = fs::absolute(argv[1]);
 
-    ConfigManager &configManager = ConfigManager::getInstance();
+    ConfigManager& configManager = ConfigManager::getInstance();
     if (!configManager.loadConfig("config.json")) {
         std::cerr << "Error: Could not load configuration." << std::endl;
         return 1;

--- a/app.py
+++ b/app.py
@@ -6,11 +6,12 @@ import json
 import logging
 import re
 from urllib.parse import urlparse
+
 """
 This is the backend of the Fast Music Remover tool.
 
-How it works:
-1) Download any YouTube video via `yt-dlp`
+Workflow:
+1) Download YouTube video via `yt-dlp`
 2) Send a processing request to the `MediaProcessor` C++ binary, which uses DeepFilterNet for fast filtering
 3) Serve the processed video on the frontend
 
@@ -22,15 +23,15 @@ app = Flask(__name__)
 with open('config.json') as config_file:
     config = json.load(config_file)
 
-DEEPFILTERNET_PATH = config['deep_filter_path']
-DOWNLOADS_DIR = config['downloads_dir']
-FFMPEG_PATH = config['ffmpeg_path']
-UPLOAD_FOLDER = config.get('upload_folder', 'uploads')  # defaults to uploads/
+# Define base paths using absolute references
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-# Set env var for DeepFilterNet path
+DEEPFILTERNET_PATH = os.path.abspath(config['deep_filter_path'])
+DOWNLOADS_DIR = os.path.abspath(config['downloads_dir'])
+FFMPEG_PATH = os.path.abspath(config['ffmpeg_path'])
+UPLOAD_FOLDER = os.path.abspath(config.get('upload_folder', os.path.join(BASE_DIR, 'uploads')))  # Defaults to uploads/
+
 os.environ['DEEPFILTERNET_PATH'] = DEEPFILTERNET_PATH
-
-# Set the uploads/ for serving media; mkdir if not found
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 class Utils:
@@ -58,7 +59,7 @@ class Utils:
     def sanitize_filename(filename):
         """Replace non-alphanumerics (except periods and underscores) with underscores."""
         return re.sub(r'[^a-zA-Z0-9._-]', '_', filename)
-    
+
     @staticmethod
     def validate_url(url):
         """Basic URL validation"""
@@ -83,19 +84,17 @@ class MediaHandler:
                 'format': 'bestvideo+bestaudio/best',
                 'outtmpl': os.path.join(app.config['UPLOAD_FOLDER'], sanitized_title + '.%(ext)s'),
                 'noplaylist': True,
-                'keepvideo': True,  # Keep source files for merging
+                'keepvideo': True,
                 'n_threads': 6
             }
 
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 result = ydl.extract_info(url, download=True)
 
-                # Post-download file-ext gymnastics
+                # Determine file extension
                 if 'requested_formats' in result:
-                    # If separate video and audio were downloaded and merged
                     merged_ext = result['ext']
                 else:
-                    # If a single file was downloaded; fallback to mp4 (which probably isn't the best idea)
                     merged_ext = result.get('ext', 'mp4')
 
             # Return the sanitized file path for processing
@@ -108,27 +107,35 @@ class MediaHandler:
 
     @staticmethod
     def process_with_media_processor(video_path):
+        """ Run the C++ MediaProcessor binary with the video path """
+
         try:
             logging.info(f"Processing video at path: {video_path}")
 
             result = subprocess.run([
-                './MediaProcessor/build/MediaProcessor', video_path
+                './MediaProcessor/build/MediaProcessor', str(video_path)
             ], capture_output=True, text=True)
 
             if result.returncode != 0:
                 logging.error(f"Error processing video: {result.stderr}")
                 return None
 
+            # Parse the output to get the processed video path (TODO: encapsulate)
             for line in result.stdout.splitlines():
                 if "Video processed successfully" in line:
-                    processed_video_path = line.split(": ")[1].strip()
+                    processed_video_path = line.split(": ", 1)[1].strip()
+                    
+                    # Remove any surrounding quotes (TODO: encapsulate)
+                    if processed_video_path.startswith('"') and processed_video_path.endswith('"'):
+                        processed_video_path = processed_video_path[1:-1]
+                    processed_video_path = os.path.abspath(processed_video_path)
+                    logging.info(f"Processed video path returned: {processed_video_path}")
                     return processed_video_path
 
             return None
         except Exception as e:
             logging.error(f"Error running C++ binary: {e}")
             return None
-
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
@@ -137,17 +144,15 @@ def index():
 
         if not Utils.validate_url(url):
             return jsonify({"status": "error", "message": "Invalid URL provided."})
-        
+
         if url:
-            # Download video via MediaHandler class
             video_path = MediaHandler.download_media(url)
-            
+
             if not video_path:
                 return jsonify({"status": "error", "message": "Failed to download video."})
-            
-            # Process video using MediaHandler class
+
             processed_video_path = MediaHandler.process_with_media_processor(video_path)
-            
+
             if processed_video_path:
                 return jsonify({
                     "status": "completed",
@@ -155,14 +160,33 @@ def index():
                 })
             else:
                 return jsonify({"status": "error", "message": "Failed to process video."})
-    
+
     return render_template('index.html')
 
 
 @app.route('/video/<filename>')
 def serve_video(filename):
-    return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
+    try:
+        # Construct the abs path for the file to be served (TODO: encapsulate)
+        file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        abs_file_path = os.path.abspath(file_path)
+        logging.debug(f"Attempting to serve video from path: {abs_file_path}")
+
+        if not os.path.exists(abs_file_path):
+            logging.error(f"File does not exist: {abs_file_path}")
+            return jsonify({"status": "error", "message": "File not found."}), 404
+
+        # Serve the file from the uploads directory
+        return send_from_directory(
+            directory=app.config['UPLOAD_FOLDER'],
+            path=filename,
+            mimetype='video/mp4'
+        )
+    except Exception as e:
+        logging.error(f"Error serving video: {e}")
+        return jsonify({"status": "error", "message": "Failed to serve video."}), 500
 
 
 if __name__ == '__main__':
     app.run(port=8080, debug=True)
+


### PR DESCRIPTION
To unblock the ongoing windows tests this much needed refactor of filepaths is now done. 
Hardcoded and/or platform specific filepaths have been fixed. 

In doing so, the ffmpeg and deepfilter commands had to be revised. So, I adapted the implementations with the `CommandBuilder` base class. These should get updated with their respective builders.

Small additional checks were needed on the backend to handle the differences introduced by `std::filesystem::path`