### PR TITLE
Add FFmpegSettingsManager to core

### DIFF
--- a/MediaProcessor/CMakeLists.txt
+++ b/MediaProcessor/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(MediaProcessor
     src/Utils.cpp
     src/CommandBuilder.cpp
     src/HardwareUtils.cpp
+    src/FFmpegSettingsManager.cpp
 )
 
 # Threads is required

--- a/MediaProcessor/src/FFmpegSettingsManager.cpp
+++ b/MediaProcessor/src/FFmpegSettingsManager.cpp
@@ -1,0 +1,99 @@
+#include "FFmpegSettingsManager.h"
+
+namespace MediaProcessor {
+
+FFmpegSettingsManager::FFmpegSettingsManager() {
+    m_audioCodecToString = {{AudioCodec::AAC, "aac"},
+                            {AudioCodec::MP3, "mp3"},
+                            {AudioCodec::FLAC, "flac"},
+                            {AudioCodec::OPUS, "opus"},
+                            {AudioCodec::UNKNOWN, "unknown"}};
+
+    m_videoCodecToString = {{VideoCodec::H264, "libx264"},
+                            {VideoCodec::H265, "libx265"},
+                            {VideoCodec::VP8, "libvpx"},
+                            {VideoCodec::VP9, "libvpx-vp9"},
+                            {VideoCodec::UNKNOWN, "unknown"}};
+}
+
+FFmpegSettingsManager& FFmpegSettingsManager::getInstance() {
+    static FFmpegSettingsManager instance;
+    return instance;
+}
+
+// Global Setters
+void FFmpegSettingsManager::setOverwrite(bool overwrite) {
+    m_globalSettings.overwrite = overwrite;
+}
+
+void FFmpegSettingsManager::setInputFile(const std::string& inputFile) {
+    m_globalSettings.inputFile = inputFile;
+}
+
+void FFmpegSettingsManager::setOutputFile(const std::string& outputFile) {
+    m_globalSettings.outputFile = outputFile;
+}
+
+// Global Getters
+bool FFmpegSettingsManager::getOverwrite() const {
+    return m_globalSettings.overwrite;
+}
+
+std::string FFmpegSettingsManager::getInputFile() const {
+    return m_globalSettings.inputFile;
+}
+
+std::string FFmpegSettingsManager::getOutputFile() const {
+    return m_globalSettings.outputFile;
+}
+
+// Audio Setters
+void FFmpegSettingsManager::setAudioCodec(AudioCodec codec) {
+    m_audioSettings.codec = codec;
+}
+
+void FFmpegSettingsManager::setAudioSampleRate(int sampleRate) {
+    m_audioSettings.sampleRate = sampleRate;
+}
+
+void FFmpegSettingsManager::setAudioChannels(int channels) {
+    m_audioSettings.numChannels = channels;
+}
+
+// Audio Getters
+AudioCodec FFmpegSettingsManager::getAudioCodec() const {
+    return m_audioSettings.codec;
+}
+
+int FFmpegSettingsManager::getAudioSampleRate() const {
+    return m_audioSettings.sampleRate;
+}
+
+int FFmpegSettingsManager::getAudioChannels() const {
+    return m_audioSettings.numChannels;
+}
+
+// Video Setters
+void FFmpegSettingsManager::setVideoCodec(VideoCodec codec) {
+    m_videoSettings.codec = codec;
+}
+
+// Video Getters
+VideoCodec FFmpegSettingsManager::getVideoCodec() const {
+    return m_videoSettings.codec;
+}
+
+template <typename T>
+std::string FFmpegSettingsManager::enumToString(
+    const T& value, const std::unordered_map<T, std::string>& valueMap) const {
+    auto it = valueMap.find(value);
+    return (it != valueMap.end()) ? it->second : "unknown";
+}
+
+// Explicit instantiations ensure the compiler generates the template for a type
+template std::string FFmpegSettingsManager::enumToString<AudioCodec>(
+    const AudioCodec& codec, const std::unordered_map<AudioCodec, std::string>& codecMap) const;
+template std::string FFmpegSettingsManager::enumToString<VideoCodec>(
+    const VideoCodec& codec, const std::unordered_map<VideoCodec, std::string>& codecMap) const;
+
+}  // namespace MediaProcessor

--- a/MediaProcessor/src/FFmpegSettingsManager.h
+++ b/MediaProcessor/src/FFmpegSettingsManager.h
@@ -1,0 +1,87 @@
+#ifndef FFMPEGSETTINGSMANAGER_H
+#define FFMPEGSETTINGSMANAGER_H
+
+#include <string>
+#include <unordered_map>
+
+#include "ConfigManager.h"
+
+namespace MediaProcessor {
+
+enum class AudioCodec { AAC, MP3, FLAC, OPUS, UNKNOWN };
+enum class VideoCodec { H264, H265, VP8, VP9, UNKNOWN };
+
+/**
+ * @class FFmpegSettingsManager
+ * @brief Manages FFmpeg-specific global, audio and video settings
+ *
+ * The FFmpegSettingsManager is a singleton that provides interfaces to set
+ * and get settings related to global, audio, and video settings.
+ *
+ * Note: This class does not manage configuration data directly.
+ * Configurations should be retrieved via the `ConfigManager`.
+ */
+class FFmpegSettingsManager {
+   public:
+    static FFmpegSettingsManager& getInstance();
+
+    // Global Setters
+    void setOverwrite(bool overwrite);
+    void setInputFile(const std::string& inputFile);
+    void setOutputFile(const std::string& outputFile);
+
+    // Global Getters
+    bool getOverwrite() const;
+    std::string getInputFile() const;
+    std::string getOutputFile() const;
+
+    // Audio Setters
+    void setAudioCodec(AudioCodec codec);
+    void setAudioSampleRate(int sampleRate);
+    void setAudioChannels(int channels);
+
+    // Audio Getters
+    AudioCodec getAudioCodec() const;
+    int getAudioSampleRate() const;
+    int getAudioChannels() const;
+
+    // Video Setters
+    void setVideoCodec(VideoCodec codec);
+
+    // Video Getters
+    VideoCodec getVideoCodec() const;
+
+    template <typename T>
+    std::string enumToString(const T& value,
+                             const std::unordered_map<T, std::string>& valueMap) const;
+
+    std::string getFFmpegPath() const {
+        return ConfigManager::getInstance().getFFmpegPath().string();
+    }
+
+   private:
+    FFmpegSettingsManager();
+
+    std::unordered_map<AudioCodec, std::string> m_audioCodecToString;
+    std::unordered_map<VideoCodec, std::string> m_videoCodecToString;
+
+    struct FFmpegGlobalSettings {
+        bool overwrite = false;
+        std::string inputFile;
+        std::string outputFile;
+    } m_globalSettings;
+
+    struct FFmpegAudioSettings {
+        AudioCodec codec = AudioCodec::AAC;
+        int sampleRate = 48000;
+        int numChannels = 2;
+    } m_audioSettings;
+
+    struct FFmpegVideoSettings {
+        VideoCodec codec = VideoCodec::H264;
+    } m_videoSettings;
+};
+
+}  // namespace MediaProcessor
+
+#endif  // FFMPEGSETTINGSMANAGER_H


### PR DESCRIPTION
An initial implementation of the FFmpegSettingsManager, which is a singleton that manages global, audio and video settings specific to ffmpeg. 
It does not manage configurations -that is done via the ConfigManager. 
It has some limited internal utility to smooth out implementations.

I don't suppose it's exhaustive, but it's a start. 