### PR TITLE
Refactor: Revise FFmpegSettingsManager's singleton behavior

### DIFF
--- a/MediaProcessor/src/FFmpegSettingsManager.cpp
+++ b/MediaProcessor/src/FFmpegSettingsManager.cpp
@@ -16,11 +16,6 @@ FFmpegSettingsManager::FFmpegSettingsManager() {
                             {VideoCodec::UNKNOWN, "unknown"}};
 }
 
-FFmpegSettingsManager& FFmpegSettingsManager::getInstance() {
-    static FFmpegSettingsManager instance;
-    return instance;
-}
-
 // Global Setters
 void FFmpegSettingsManager::setOverwrite(bool overwrite) {
     m_globalSettings.overwrite = overwrite;
@@ -90,7 +85,7 @@ std::string FFmpegSettingsManager::enumToString(
     return (it != valueMap.end()) ? it->second : "unknown";
 }
 
-// Explicit instantiations ensure the compiler generates the template for a type
+// Explicit template instantiations for AudioCodec and VideoCodec
 template std::string FFmpegSettingsManager::enumToString<AudioCodec>(
     const AudioCodec& codec, const std::unordered_map<AudioCodec, std::string>& codecMap) const;
 template std::string FFmpegSettingsManager::enumToString<VideoCodec>(

--- a/MediaProcessor/src/FFmpegSettingsManager.h
+++ b/MediaProcessor/src/FFmpegSettingsManager.h
@@ -4,7 +4,11 @@
 #include <string>
 #include <unordered_map>
 
-#include "ConfigManager.h"
+/**
+ * TODO:
+ * Having input/output file operations in the settings manager is not nice.
+ * These should be handled as the command is built, within the FFmpegCommandBuilder class.
+ */
 
 namespace MediaProcessor {
 
@@ -12,20 +16,14 @@ enum class AudioCodec { AAC, MP3, FLAC, OPUS, UNKNOWN };
 enum class VideoCodec { H264, H265, VP8, VP9, UNKNOWN };
 
 /**
- * @brief Manages FFmpeg-specific global, audio, and video settings.
+ * @brief Manages settings for FFmpeg-specific global, audio, and video settings.
  *
- * The FFmpegSettingsManager is a singleton that provides interfaces to set
- * and get settings for global, audio, and video configurations.
- *
- * Note: This class does not manage configuration data directly. Configurations
- * should be retrieved via the `ConfigManager`.
+ * Provides an interface for setting and retrieving configuration options,
+ * including file paths, codecs, and other processing parameters.
  */
 class FFmpegSettingsManager {
    public:
-    /**
-     * @brief Retrieves the singleton instance of FFmpegSettingsManager.
-     */
-    static FFmpegSettingsManager& getInstance();
+    FFmpegSettingsManager();
 
     // Global Setters
     void setOverwrite(bool overwrite);
@@ -65,18 +63,7 @@ class FFmpegSettingsManager {
     std::string enumToString(const T& value,
                              const std::unordered_map<T, std::string>& valueMap) const;
 
-    /**
-     * @brief Retrieves the path to the FFmpeg executable.
-     *
-     * @return The FFmpeg path as a string.
-     */
-    std::string getFFmpegPath() const {
-        return ConfigManager::getInstance().getFFmpegPath().string();
-    }
-
    private:
-    FFmpegSettingsManager();
-
     std::unordered_map<AudioCodec, std::string> m_audioCodecToString;
     std::unordered_map<VideoCodec, std::string> m_videoCodecToString;
 


### PR DESCRIPTION
Singleton behavior here would become a serious limitation across the board including unit testing.
It also was not sensible as the user side does not fit well with this behavior. I/O file management to be moved into the respective command builder.