### PR TITLE
Feature: Add FFmpegControllerBuilder to core (#58)

### DIFF
--- a/MediaProcessor/src/FFmpegController.h
+++ b/MediaProcessor/src/FFmpegController.h
@@ -1,0 +1,18 @@
+#ifndef FFMPEGCONTROLLER_H
+#define FFMPEGCONTROLLER_H
+
+#include "FFmpegSettingsManager.h"
+
+namespace MediaProcessor {
+
+class FFmpegController {
+   public:
+    FFmpegController(const FFmpegSettingsManager& ffmpegSettings);
+
+   private:
+    FFmpegSettingsManager& m_ffmpegSettings;
+};
+
+}  // namespace MediaProcessor
+
+#endif /* FFMPEGCONTROLLER_H */

--- a/MediaProcessor/src/FFmpegControllerBuilder.cpp
+++ b/MediaProcessor/src/FFmpegControllerBuilder.cpp
@@ -1,0 +1,47 @@
+#include "FFmpegControllerBuilder.h"
+
+#include "FFmpegController.h"
+#include "FFmpegSettingsManager.h"
+
+namespace MediaProcessor {
+
+FFmpegControllerBuilder::FFmpegControllerBuilder() : m_ffmpegSettings(FFmpegSettingsManager()) {}
+
+FFmpegControllerBuilder::FFmpegControllerBuilder(FFmpegSettingsManager& ffmpegSettings)
+    : m_ffmpegSettings(std::move(ffmpegSettings)) {}
+
+FFmpegControllerBuilder& FFmpegControllerBuilder::setOverwrite(bool overwrite) {
+    m_ffmpegSettings.setOverwrite(overwrite);
+
+    return *this;
+}
+
+FFmpegControllerBuilder& FFmpegControllerBuilder::setAudioCodec(AudioCodec codec) {
+    m_ffmpegSettings.setAudioCodec(codec);
+
+    return *this;
+}
+
+FFmpegControllerBuilder& FFmpegControllerBuilder::setAudioSampleRate(int sampleRate) {
+    m_ffmpegSettings.setAudioSampleRate(sampleRate);
+
+    return *this;
+}
+
+FFmpegControllerBuilder& FFmpegControllerBuilder::setAudioChannels(int numChannels) {
+    m_ffmpegSettings.setAudioChannels(numChannels);
+
+    return *this;
+}
+
+FFmpegControllerBuilder& FFmpegControllerBuilder::setVideoCodec(VideoCodec codec) {
+    m_ffmpegSettings.setVideoCodec(codec);
+
+    return *this;
+}
+
+std::unique_ptr<FFmpegController> FFmpegControllerBuilder::build() const {
+    return std::make_unique<FFmpegController>(std::move(m_ffmpegSettings));
+}
+
+}  // namespace MediaProcessor

--- a/MediaProcessor/src/FFmpegControllerBuilder.h
+++ b/MediaProcessor/src/FFmpegControllerBuilder.h
@@ -1,0 +1,82 @@
+#ifndef FFMPEGCONTROLLERBUILDER_H
+#define FFMPEGCONTROLLERBUILDER_H
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "CommandBuilder.h"
+#include "ConfigManager.h"
+#include "FFmpegController.h"
+#include "FFmpegSettingsManager.h"
+
+namespace MediaProcessor {
+
+/**
+ * @brief Builds FFmpegController and FFmpegSettingsManager objects
+ *
+ * Provides an interface for setting FFmpeg-specific configuration options with
+ * FFmpegSettingsManager and builds a FFmpegController with the given settings
+ */
+class FFmpegControllerBuilder {
+   public:
+    FFmpegControllerBuilder();
+
+    /**
+     * @brief Initializes the FFmpegControllerBuilder with FFmpegSettingsManager
+     *
+     * This constructor will only accept references to FFmpegSettingsManager
+     * objects. Copy initialization is disallowed, and FFmpegControllerManger
+     * takes ownership of the reference.
+     */
+    explicit FFmpegControllerBuilder(FFmpegSettingsManager& ffmpegSettings);
+
+    /**
+     * @brief Sets the overwrite flag
+     *
+     * @return A reference to the current object for method chaining
+     */
+    FFmpegControllerBuilder& setOverwrite(bool overwrite);
+
+    /**
+     * @brief Sets the audio codec
+     *
+     * @return A reference to the current object for method chaining
+     */
+    FFmpegControllerBuilder& setAudioCodec(AudioCodec codec);
+
+    /**
+     * @brief Sets the audio sample rate
+     *
+     * @return A reference to the current object for method chaining
+     */
+    FFmpegControllerBuilder& setAudioSampleRate(int sampleRate);
+
+    /**
+     * @brief Sets the number of audio channels
+     *
+     * @return A reference to the current object for method chaining
+     */
+    FFmpegControllerBuilder& setAudioChannels(int numChannels);
+
+    /**
+     * @brief Sets the video codec
+     *
+     * @return A reference to the current object for method chaining
+     */
+    FFmpegControllerBuilder& setVideoCodec(VideoCodec codec);
+
+    /**
+     * @brief Builds a FFmpegController
+     *
+     * @return A unique pointer to an instance FFmpegController
+     */
+    std::unique_ptr<FFmpegController> build() const;
+
+   private:
+    FFmpegSettingsManager m_ffmpegSettings;
+};
+
+}  // namespace MediaProcessor
+
+#endif /* FFMPEGCONTROLLERBUILDER_H */

--- a/MediaProcessor/src/FFmpegSettingsManager.h
+++ b/MediaProcessor/src/FFmpegSettingsManager.h
@@ -51,8 +51,6 @@ class FFmpegSettingsManager {
 
     struct FFmpegGlobalSettings {
         bool overwrite = false;
-        std::string inputFile;
-        std::string outputFile;
     } m_globalSettings;
 
     struct FFmpegAudioSettings {


### PR DESCRIPTION
This PR closes #58 and makes the following changes:

1. Removed the input/output file vars from `FFmpegSettingsManager`. Other references to those vars were already removed in #51.
2. Added the header for FFmpegController. The final implementation will come down to how we progress on the current class, however I already hit my 4 for hacktoberfest - no big deal if you want it included with this PR.
3. Added FFmpegControllerBuilder. This new class will accept the settings for FFmpegSettingsManager and return a unique ptr to a FFmpegController. The intent is that ownership of all references will be transferred to the newly built Controller, which I felt was especially important in the case where the builder receives a reference and passes it back.