### PR TITLE
Updated pyproject.toml: configured black to use line-length = 120

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.isort]
 profile = "black"
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
A little Improvement. Curretly we have to manualy put 
```bash
black . --line-length 120
```
before each command
but now we can do
```bash
black .
```