### PR TITLE
Add CI platform tests with a temporary workaround for current config limitations

### DIFF
--- a/.github/workflows/build_test_and_format_core.yml
+++ b/.github/workflows/build_test_and_format_core.yml
@@ -9,17 +9,23 @@ on:
       - main
 
 jobs:
-  test:
+  test-linux:
+    name: Linux Test
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Install Dependencies
+      - name: Install Dependencies on Linux
         run: |
           sudo apt update
           sudo apt install -y ffmpeg cmake nlohmann-json3-dev libsndfile1-dev g++
+
+      - name: Update Config Paths for Linux
+        run: |
+          sed -i 's|"deep_filter_path": ".*"|"deep_filter_path": "MediaProcessor/lib/libdf.so"|' config.json
+          sed -i 's|"ffmpeg_path": ".*"|"ffmpeg_path": "/usr/bin/ffmpeg"|' config.json
 
       - name: Build with Tests Enabled
         run: |
@@ -33,7 +39,69 @@ jobs:
           cd build
           ctest --output-on-failure
 
+  test-windows:
+    name: Windows Test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies on Windows
+        run: |
+          choco install ffmpeg cmake -y
+          curl -L -o nlohmann-json.zip https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp.zip
+          tar -xf nlohmann-json.zip
+
+      - name: Update Config Paths for Windows
+        run: |
+          sed -i 's|"deep_filter_path": ".*"|"deep_filter_path": "MediaProcessor/lib/df.dll"|' config.json
+          sed -i 's|"ffmpeg_path": ".*"|"ffmpeg_path": "ffmpeg"|' config.json
+
+      - name: Build with Tests Enabled
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release ../MediaProcessor
+          cmake --build . --config Release
+
+      - name: Run Tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  test-macos:
+    name: macOS ARM Test
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies on macOS ARM
+        run: |
+          brew update
+          brew install ffmpeg cmake nlohmann-json libsndfile
+
+      - name: Update Config Paths for macOS ARM
+        run: |
+          sed -i '' 's|"deep_filter_path": ".*"|"deep_filter_path": "MediaProcessor/lib/libdf.dylib"|' config.json
+          sed -i '' 's|"ffmpeg_path": ".*"|"ffmpeg_path": "/usr/local/bin/ffmpeg"|' config.json
+
+      - name: Build with Tests Enabled
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release ../MediaProcessor
+          cmake --build . --config Release
+
+      - name: Run Tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
   format:
+    name: Format Check
     runs-on: ubuntu-latest
 
     steps:

--- a/MediaProcessor/src/AudioProcessor.cpp
+++ b/MediaProcessor/src/AudioProcessor.cpp
@@ -224,8 +224,8 @@ bool AudioProcessor::filterChunks() {
         results.emplace_back(pool.enqueue([&, i]() {
             fs::path chunkPath = m_chunkPathCol[i];
 
-            invokeDeepFilter(chunkPath);
-            // invokeDeepFilterFFI(chunkPath);  // RT API still under validation
+            // invokeDeepFilter(chunkPath);
+            invokeDeepFilterFFI(chunkPath);
         }));
     }
 


### PR DESCRIPTION
As part of #67 the configurations should be dynamically loaded. 
This is a hacky test to see if we can use this in the meantime for platform tests.