### PR TITLE
Add audio support to core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y build-essential cmake ffmpeg wget pkg-config \
                        libavcodec-dev libavformat-dev libavfilter-dev \
-                       libavdevice-dev libswscale-dev libsndfile-dev && \
+                       libavdevice-dev libswscale-dev libsndfile-dev git && \
     apt-get clean
-
-# pkg manager doesn't find this?
-RUN mkdir -p /usr/include/nlohmann && \
-    wget https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp -O /usr/include/nlohmann/json.hpp
 
 WORKDIR /app
 
@@ -21,15 +17,19 @@ COPY . /app
 # Compile the C++ project with a fresh CMakeCache (issues with cache not matching source)
 RUN mkdir -p MediaProcessor/build && \
     cd MediaProcessor/build && \
-    rm -rf CMakeCache.txt && \
+    rm -rf CMakeCache.txt CMakeFiles _deps && \
     cmake .. && \
     make
 
 # Install python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Set Flask environment variables
 ENV FLASK_APP=app.py
 ENV FLASK_ENV=development
 
+# Expose the port for Flask
 EXPOSE 8080
+
+# Run Flask application
 CMD ["flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/MediaProcessor/CMakeLists.txt
+++ b/MediaProcessor/CMakeLists.txt
@@ -1,36 +1,40 @@
 cmake_minimum_required(VERSION 3.10)
 project(MediaProcessor)
 
-# C++17 or above is required
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Release build by default
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
-# Tests are excluded by default, use `cmake -DBUILD_TESTING=ON` to build with tests.
+include(FetchContent)
+set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/_deps") # helps with Docker to resolve
+
 option(BUILD_TESTING "Test Build" OFF)
 
-# Set include directories
 include(CTest)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-# Threads is required
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# SNDFILE: for read/write of sampled audio files
-# https://github.com/libsndfile/libsndfile
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SNDFILE REQUIRED sndfile)
 include_directories(${SNDFILE_INCLUDE_DIRS})
+
+FetchContent_Declare(
+  nlohmann_json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
 
 # Include the cmake files under cmake/
 include(cmake/src.cmake)
 if(BUILD_TESTING)
     include(cmake/test.cmake)
 endif()
+

--- a/MediaProcessor/cmake/src.cmake
+++ b/MediaProcessor/cmake/src.cmake
@@ -5,6 +5,7 @@ add_executable(MediaProcessor
     ${CMAKE_SOURCE_DIR}/src/ConfigManager.cpp
     ${CMAKE_SOURCE_DIR}/src/AudioProcessor.cpp
     ${CMAKE_SOURCE_DIR}/src/VideoProcessor.cpp
+    ${CMAKE_SOURCE_DIR}/src/MediaProcessor.cpp
     ${CMAKE_SOURCE_DIR}/src/Utils.cpp
     ${CMAKE_SOURCE_DIR}/src/CommandBuilder.cpp
     ${CMAKE_SOURCE_DIR}/src/HardwareUtils.cpp
@@ -38,6 +39,8 @@ target_link_libraries(MediaProcessor PRIVATE
     Threads::Threads
     ${SNDFILE_LIBRARIES}
     ${DF_LIBRARY}
+    nlohmann_json::nlohmann_json
+
 )
 
 # Some of this was for macOS try to remove if possible
@@ -47,7 +50,3 @@ set_target_properties(MediaProcessor PROPERTIES
     BUILD_RPATH "${CMAKE_SOURCE_DIR}/lib"
     INSTALL_RPATH_USE_LINK_PATH TRUE
 )
-
-# Find and link the JSON lib
-find_package(nlohmann_json 3.10.5 REQUIRED)
-target_link_libraries(MediaProcessor PRIVATE nlohmann_json::nlohmann_json)

--- a/MediaProcessor/src/AudioProcessor.h
+++ b/MediaProcessor/src/AudioProcessor.h
@@ -36,9 +36,9 @@ class AudioProcessor {
     fs::path m_outputAudioPath;
     fs::path m_outputPath;
     fs::path m_chunksPath;
-    fs::path m_processedChunksDir;
-    std::vector<fs::path> m_chunkPathCol;
-    std::vector<fs::path> m_processedChunkCol;
+    fs::path m_processedChunksPath;
+    std::vector<fs::path> m_chunkColPath;
+    std::vector<fs::path> m_processedChunkColPath;
 
     int m_numChunks;
 

--- a/MediaProcessor/src/MediaProcessor.cpp
+++ b/MediaProcessor/src/MediaProcessor.cpp
@@ -1,0 +1,87 @@
+#include "MediaProcessor.h"
+
+#include <iostream>
+
+#include "AudioProcessor.h"
+#include "ConfigManager.h"
+#include "Utils.h"
+#include "VideoProcessor.h"
+
+namespace MediaProcessor {
+
+MediaProcessor::MediaProcessor(const std::filesystem::path& mediaPath)
+    : m_mediaPath(std::filesystem::absolute(mediaPath)) {}
+
+bool MediaProcessor::process() {
+    ConfigManager& configManager = ConfigManager::getInstance();
+    if (!configManager.loadConfig("config.json")) {
+        std::cerr << "Error: Could not load configuration." << std::endl;
+        return false;
+    }
+
+    MediaType mediaType;
+    TRY(mediaType = getMediaType());
+
+    switch (mediaType) {
+        case MediaType::Audio:
+            return processAudio();
+        case MediaType::Video:
+            return processVideo();
+        default:
+            std::cerr << "Unsupported file type." << std::endl;
+            return false;
+    }
+}
+
+bool MediaProcessor::processAudio() {
+    AudioProcessor audioProcessor(m_mediaPath, Utils::prepareAudioOutputPath(m_mediaPath));
+    if (!audioProcessor.isolateVocals()) {
+        std::cerr << "Failed to process audio." << std::endl;
+        return false;
+    }
+    std::cout << "Audio processed successfully: " << Utils::prepareAudioOutputPath(m_mediaPath)
+              << std::endl;
+    return true;
+}
+
+bool MediaProcessor::processVideo() {
+    auto [extractedVocalsPath, processedMediaPath] = Utils::prepareOutputPaths(m_mediaPath);
+    AudioProcessor audioProcessor(m_mediaPath, extractedVocalsPath);
+
+    if (!audioProcessor.isolateVocals()) {
+        std::cerr << "Failed to extract vocals from video." << std::endl;
+        return false;
+    }
+
+    VideoProcessor videoProcessor(m_mediaPath, extractedVocalsPath, processedMediaPath);
+    if (!videoProcessor.mergeMedia()) {
+        std::cerr << "Failed to merge audio and video." << std::endl;
+        return false;
+    }
+
+    std::cout << "Video processed successfully: " << processedMediaPath << std::endl;
+    return true;
+}
+
+MediaType MediaProcessor::getMediaType() const {
+    const std::string command =
+        "ffprobe -loglevel error -show_entries stream=codec_type "
+        "-of default=noprint_wrappers=1:nokey=1 \"" +
+        m_mediaPath.string() + "\"";
+
+    std::optional<std::string> output = Utils::runCommand(command, true);
+    if (!output || output->empty()) {
+        throw std::runtime_error("Failed to detect media type.");
+    }
+
+    std::string_view result = *output;
+    if (result.find("video") != std::string_view::npos) {
+        return MediaType::Video;
+    } else if (result.find("audio") != std::string_view::npos) {
+        return MediaType::Audio;
+    } else {
+        throw std::runtime_error("Unsupported media type detected.");
+    }
+}
+
+}  // namespace MediaProcessor

--- a/MediaProcessor/src/MediaProcessor.h
+++ b/MediaProcessor/src/MediaProcessor.h
@@ -1,0 +1,53 @@
+#ifndef MEDIAPROCESSOR_H
+#define MEDIAPROCESSOR_H
+
+#include <filesystem>
+
+namespace MediaProcessor {
+
+enum class MediaType { Audio, Video, Unsupported };
+
+class MediaProcessor {
+   public:
+    explicit MediaProcessor(const std::filesystem::path& mediaPath);
+
+    /**
+     * @brief Processes a media file (audio or video) to isolate vocals.
+     *
+     * Processes the media file located at m_mediaPath. Processing is dynamically
+     * adjusted by detecting file type, i.e. audio or video.
+     *
+     * @return true if processing was successful, false otherwise.
+     */
+    bool process();
+
+   private:
+    std::filesystem::path m_mediaPath;
+
+    /**
+     * @brief Processes an audio file.
+     *
+     * @return true if processing was successful, false otherwise.
+     */
+    bool processAudio();
+
+    /**
+     * @brief Processes a video file by extracting and isolating vocals and merges back to source.
+     *
+     * @return true if processing was successful, false otherwise.
+     */
+    bool processVideo();
+
+    /**
+     * @brief Detects the media type (audio or video) of the file located at m_mediaPath.
+     *
+     * @return MediaType of the file.
+     *
+     * @throws std::runtime_error if detection fails.
+     */
+    MediaType getMediaType() const;
+};
+
+}  // namespace MediaProcessor
+
+#endif  // MEDIAPROCESSOR_H

--- a/MediaProcessor/src/Utils.h
+++ b/MediaProcessor/src/Utils.h
@@ -2,6 +2,8 @@
 #define UTILS_H
 
 #include <filesystem>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -11,11 +13,31 @@ namespace fs = std::filesystem;
 namespace MediaProcessor::Utils {
 
 /**
+ * @brief Macro to handle exceptions.
+ */
+#define TRY(expression)                                  \
+    try {                                                \
+        expression;                                      \
+    } catch (const std::exception &e) {                  \
+        std::cerr << "Error: " << e.what() << std::endl; \
+        return false;                                    \
+    }
+
+/**
  * @brief Executes a command in the system shell.
  *
  * @return true if the command executes successfully, false otherwise.
  */
 bool runCommand(const std::string &command);
+
+/**
+ * @brief Executes a shell command and optionally returns its output
+ *
+ * This is used when the output of the command is of interest, and not just a success state.
+ *
+ * @return std::optional<std::string> possibly containing the command output.
+ */
+std::optional<std::string> runCommand(const std::string &command, bool captureOutput);
 
 /**
  * @brief Ensures that a directory exists, making it if necessary.
@@ -44,6 +66,13 @@ bool containsWhitespace(const std::string &str);
  * @return A pair containing the output audio path and the output video path.
  */
 std::pair<fs::path, fs::path> prepareOutputPaths(const fs::path &videoPath);
+
+/**
+ * @brief Prepares the output path for audio processing only.
+ *
+ * @return A std::filesystem::path containing the output path for the processed audio.
+ */
+fs::path prepareAudioOutputPath(const fs::path &inputPath);
 
 /**
  * @brief Trims trailing whitespace from a string.
@@ -75,6 +104,7 @@ bool isWithinRange(T value, T lowerBound, T upperBound) {
  * @tparam T Enum type.
  * @param value The enum value.
  * @param valueMap Map of enum values to their string representations.
+ *
  * @return The string representation of the enum value.
  */
 template <typename T>

--- a/MediaProcessor/src/main.cpp
+++ b/MediaProcessor/src/main.cpp
@@ -1,61 +1,48 @@
-#include <filesystem>
 #include <iostream>
-#include <string>
 
-#include "AudioProcessor.h"
-#include "ConfigManager.h"
-#include "Utils.h"
-#include "VideoProcessor.h"
-
-namespace fs = std::filesystem;
+#include "MediaProcessor.h"
 
 using namespace MediaProcessor;
 
 int main(int argc, char* argv[]) {
     /**
-     * @brief Processes a video file to isolate vocals and merge them back with the original video.
+     * @brief Processes a media file (audio or video) to isolate vocals and output the processed
+     * result.
      *
      * This program removes music, sound effects, and noise while retaining clear vocals.
+     * It supports both audio and video files, adapting the workflow based on the file type.
      *
      * Workflow:
      *   1. Load configuration from "config.json".
-     *   2. Extract and isolate vocals using DeepFilterNet.
-     *   3. Process the audio in chunks with parallel processing.
-     *   4. Merge the isolated vocals back with the original video.
+     *   2. Determine if the input file is audio or video.
+     *   3. For audio files:
+     *      - Directly process audio to isolate vocals.
+     *   4. For video files:
+     *      - Extract and isolate vocals from the audio track.
+     *      - Process the audio in chunks with parallel processing.
+     *      - Merge the isolated vocals back with the original video.
      *
      * @param argc Number of command-line arguments.
      * @param argv Array of command-line argument strings.
      * @return Exit status code (0 for success, non-zero for failure).
      *
-     * Usage: <executable> <video_file_path>
+     * Usage: <executable> <media_file_path>
+     *
+     * Example:
+     *   - For video: <executable> input_video.mp4
+     *   - For audio: <executable> input_audio.wav
      */
 
     if (argc != 2) {
-        std::cerr << "Usage: " << argv[0] << " <video_file_path>" << std::endl;
-        return 1;
-    }
-    fs::path inputMediaPath = fs::absolute(argv[1]);
-
-    ConfigManager& configManager = ConfigManager::getInstance();
-    if (!configManager.loadConfig("config.json")) {
-        std::cerr << "Error: Could not load configuration." << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <media_file_path>" << std::endl;
         return 1;
     }
 
-    auto [extractedVocalsPath, processedMediaPath] = Utils::prepareOutputPaths(inputMediaPath);
-
-    AudioProcessor audioProcessor(inputMediaPath, extractedVocalsPath);
-    if (!audioProcessor.isolateVocals()) {
-        std::cerr << "Failed to extract vocals." << std::endl;
+    MediaProcessor::MediaProcessor processor(argv[1]);
+    if (!processor.process()) {
+        std::cerr << "Media processing failed." << std::endl;
         return 1;
     }
 
-    VideoProcessor videoProcessor(inputMediaPath, extractedVocalsPath, processedMediaPath);
-    if (!videoProcessor.mergeMedia()) {
-        std::cerr << "Failed to merge audio and video." << std::endl;
-        return 1;
-    }
-
-    std::cout << "Video processed successfully: " << processedMediaPath << std::endl;
     return 0;
 }


### PR DESCRIPTION
This PR introduces support for audio files to core, in a backwards compatible manner.
The `MediaProcessor` class introduced here handles detecting the media format via `ffprobe`, and invokes the appropriate processing pipeline accordingly. 
This also had an added benefit of significantly cleaning up `main`, and a cmake/docker-related bug was discovered and fixed. 