### PR TITLE
Add audio support downstream

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -259,9 +259,15 @@ h1 {
     margin-top: 15px;
     margin-bottom: 20px;
 }
-#videoPlayer {
+#videoPlayer, #audioPlayer {
     display: none;
-    margin-top: 20px;
+    margin: 0;
+    padding: 0;
     width: 100%;
-    max-width: 800px;
+    max-width: 800px
 }
+
+#videoPlayer.active, #audioPlayer.active {
+    display: block;
+}
+

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -109,8 +109,16 @@ function submitForm() {
     .then(response => response.json())
     .then(data => {
         if (data.status === "completed") {
-            document.getElementById("videoPlayer").src = data.video_url;
-            document.getElementById("videoPlayer").style.display = "block";
+            const fileType = data.file_type
+            const mediaUrl = data.media_url;
+
+            const activePlayer = fileType === "audio" ? document.getElementById("audioPlayer") : document.getElementById("videoPlayer");
+            const inactivePlayer = fileType === "audio" ? document.getElementById("videoPlayer") : document.getElementById("audioPlayer");
+
+            activePlayer.src = mediaUrl;
+            activePlayer.style.display = "block";
+            inactivePlayer.style.display = "none";
+
             status.textContent = "";
 
             processButton.style.backgroundColor = "#28a745"; // Green
@@ -118,13 +126,14 @@ function submitForm() {
 
             setTimeout(() => {
                 processButton.style.backgroundColor = "#6c5ce7"; // Purple
-                processButton.textContent = "Process Video";
+                processButton.textContent = "Process Media";
             }, 3000);
         } else {
             status.textContent = data.message || "An error occurred!";
         }
     })
-    .catch(() => {
+    .catch((error) => {
+        console.error("Error while connecting to the server:", error);
         status.textContent = "An error occurred while connecting to the server.";
     });
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,11 +50,14 @@
             </div>
         </div>
 
-        <button type="button" class="button" onclick="submitForm()">Process Video</button>
+        <button type="button" class="button" onclick="submitForm()">Process Media</button>
         <p id="status"></p>
         <video id="videoPlayer" controls>
             Your browser does not support the video tag.
         </video>
+        <audio id="audioPlayer" controls>
+            Your browser does not support the audio tag.
+        </audio>        
     </div>
 
     <script src="/static/js/scripts.js"></script>


### PR DESCRIPTION
This PR extends support for audio files to downstream of `MediaProcessor`, i.e. the backend and frontend.

A media file type determination -with a bit of redundancy between the core- has been added to the backend. 
This is mainly a fast fix that for something that was otherwise blocking direct audio support on the web application. 
The functionality exists within the core, but not yet decided how it will be exposed.

In addition, the frontend was updated to differentiate between the two media types and represent them appropriately.
