### PR TITLE
Add core support for dynamic filter strength

### DIFF
--- a/MediaProcessor/CMakeLists.txt
+++ b/MediaProcessor/CMakeLists.txt
@@ -26,6 +26,14 @@ pkg_check_modules(SNDFILE REQUIRED sndfile)
 include_directories(${SNDFILE_INCLUDE_DIRS})
 
 FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG 11.0.0
+)
+FetchContent_MakeAvailable(fmt)
+
+# JSON library
+FetchContent_Declare(
   nlohmann_json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
   GIT_TAG v3.11.3
@@ -37,4 +45,3 @@ include(cmake/src.cmake)
 if(BUILD_TESTING)
     include(cmake/test.cmake)
 endif()
-

--- a/MediaProcessor/cmake/src.cmake
+++ b/MediaProcessor/cmake/src.cmake
@@ -40,8 +40,10 @@ target_link_libraries(MediaProcessor PRIVATE
     ${SNDFILE_LIBRARIES}
     ${DF_LIBRARY}
     nlohmann_json::nlohmann_json
-
+    fmt::fmt
 )
+
+target_compile_options(MediaProcessor PRIVATE -D_GLIBCXX_USE_CXX23_ABI)
 
 # Some of this was for macOS try to remove if possible
 set_target_properties(MediaProcessor PROPERTIES

--- a/MediaProcessor/cmake/test.cmake
+++ b/MediaProcessor/cmake/test.cmake
@@ -15,8 +15,15 @@ endif()
 # Setup test media directory
 set(TEST_MEDIA_DIR "${CMAKE_SOURCE_DIR}/tests/TestMedia" CACHE PATH "Path to test media files")
 
+FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.0.0
+)
+FetchContent_MakeAvailable(fmt)
+
 # Common libraries for all test targets
-set(COMMON_LIBRARIES gtest_main ${CMAKE_SOURCE_DIR}/lib/libdf.so ${SNDFILE_LIBRARIES})
+set(COMMON_LIBRARIES gtest_main ${CMAKE_SOURCE_DIR}/lib/libdf.so ${SNDFILE_LIBRARIES} fmt::fmt)
 
 # Macro for adding a test executable
 macro(add_test_executable name)

--- a/MediaProcessor/src/AudioProcessor.h
+++ b/MediaProcessor/src/AudioProcessor.h
@@ -47,6 +47,7 @@ class AudioProcessor {
 
     double m_totalDuration;
     double m_overlapDuration;
+    float m_filterAttenuationLimit;
 
     ConfigManager& m_configManager;
 

--- a/MediaProcessor/src/ConfigManager.cpp
+++ b/MediaProcessor/src/ConfigManager.cpp
@@ -1,5 +1,7 @@
 #include "ConfigManager.h"
 
+#include <fmt/format.h>
+
 #include <fstream>
 #include <iostream>
 
@@ -45,6 +47,22 @@ fs::path ConfigManager::getDeepFilterDecoderPath() const {
 
 fs::path ConfigManager::getFFmpegPath() const {
     return getConfigValue<std::string>("ffmpeg_path");
+}
+
+float ConfigManager::getFilterAttenuationLimit() const {
+    auto candidateLimit = getConfigValue<float>("filter_attenuation_limit");
+    validateFilterAttenuationLimit(candidateLimit);
+
+    return candidateLimit;
+}
+
+void ConfigManager::validateFilterAttenuationLimit(float candidateLimit) const {
+    if (not Utils::isWithinRange(candidateLimit, 0.0f, 100.0f)) {
+        throw std::runtime_error(
+            fmt::format("Filter attenuation limit {}"
+                        " is not valid. Limit must be within [0.0, 100.0]",
+                        candidateLimit));
+    }
 }
 
 unsigned int ConfigManager::getOptimalThreadCount() {

--- a/MediaProcessor/src/ConfigManager.h
+++ b/MediaProcessor/src/ConfigManager.h
@@ -32,6 +32,15 @@ class ConfigManager {
     fs::path getFFmpegPath() const;
 
     /**
+     * @brief Validates and returns the attenuation value or throws!
+     *
+     * @returns the attenaution value if it's between [0.0f, 100.0f]
+     *
+     * @throws std::runtime_error if the value provided is not within [0.0f, 100.0f]
+     */
+    float getFilterAttenuationLimit() const;
+
+    /**
      * @brief Gets the optimal number of threads for processing.
      *
      * @return The optimal thread count based on configuration and hardware.
@@ -53,6 +62,13 @@ class ConfigManager {
      */
     unsigned int determineNumThreads(unsigned int configNumThreads,
                                      unsigned int hardwareNumThreads);
+
+    /**
+     * @brief Ensures the provided filter attenuation parameter is valid
+     *
+     * @throws std::runtime_error if the value provided is not within [0.0f, 100.0f]
+     */
+    void validateFilterAttenuationLimit(float candidate) const;
 
     template <typename T>
     T getConfigValue(const std::string& optionName) const;

--- a/MediaProcessor/src/MediaProcessor.cpp
+++ b/MediaProcessor/src/MediaProcessor.cpp
@@ -20,7 +20,7 @@ bool MediaProcessor::process() {
     }
 
     MediaType mediaType;
-    TRY(mediaType = getMediaType());
+    mediaType = TRY(getMediaType());
 
     switch (mediaType) {
         case MediaType::Audio:

--- a/MediaProcessor/src/Utils.h
+++ b/MediaProcessor/src/Utils.h
@@ -15,13 +15,15 @@ namespace MediaProcessor::Utils {
 /**
  * @brief Macro to handle exceptions.
  */
-#define TRY(expression)                                  \
-    try {                                                \
-        expression;                                      \
-    } catch (const std::exception& e) {                  \
-        std::cerr << "Error: " << e.what() << std::endl; \
-        return false;                                    \
-    }
+#define TRY(expression)                                      \
+    ([&]() -> decltype(auto) {                               \
+        try {                                                \
+            return (expression);                             \
+        } catch (const std::exception& e) {                  \
+            std::cerr << "Error: " << e.what() << std::endl; \
+            throw;                                           \
+        }                                                    \
+    }())
 
 /**
  * @brief Executes a command in the system shell.

--- a/MediaProcessor/tests/ConfigManagerTester.cpp
+++ b/MediaProcessor/tests/ConfigManagerTester.cpp
@@ -30,7 +30,9 @@ TEST_F(ConfigManagerTest, LoadValidConfigFile_Succeeds) {
         {"downloads_path", "downloads"},
         {"uploads_path", "uploads"},
         {"use_thread_cap", true},
-        {"max_threads_if_capped", 1}};
+        {"max_threads_if_capped", 1},
+        {"filter_attenuation_limit", 100.0f},
+    };
 
     testConfigFile.generateConfigFile("testConfig.json", jsonObject);
 
@@ -47,6 +49,8 @@ TEST_F(ConfigManagerTest, LoadValidConfigFile_Succeeds) {
     EXPECT_EQ(configManager.getFFmpegPath(), jsonObject["ffmpeg_path"].get<std::string>());
     EXPECT_EQ(configManager.getOptimalThreadCount(),
               jsonObject["max_threads_if_capped"].get<unsigned int>());
+    EXPECT_EQ(configManager.getFilterAttenuationLimit(),
+              jsonObject["filter_attenuation_limit"].get<float>());
 }
 
 TEST_F(ConfigManagerTest, LoadInvalidConfigFile) {
@@ -68,7 +72,8 @@ TEST_F(ConfigManagerTest, LoadInvalidConfigOptions) {
                                  {"downloads_path", false},
                                  {"uploads_path", false},
                                  {"use_thread_cap", "true"},
-                                 {"max_threads_if_capped", -1}};
+                                 {"max_threads_if_capped", -1},
+                                 {"filter_attenuation_limit", 100.0f}};
 
     testConfigFile.generateConfigFile("testConfig.json", jsonObject);
 

--- a/MediaProcessor/tests/TestUtils.h
+++ b/MediaProcessor/tests/TestUtils.h
@@ -87,7 +87,8 @@ class TestConfigFile {
         {"downloads_path", "downloads"},
         {"uploads_path", "uploads"},
         {"use_thread_cap", false},
-        {"max_threads_if_capped", 6}};
+        {"max_threads_if_capped", 6},
+        {"filter_attenuation_limit", 100.0f}};
 };
 
 /**

--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
     "downloads_path": "downloads",
     "uploads_path": "uploads",
     "use_thread_cap": false,
-    "max_threads_if_capped": 6
+    "max_threads_if_capped": 6,
+    "filter_attenuation_limit": 100.0
 }


### PR DESCRIPTION
This PR introduces core support for dynamic selection of filtering strength, to allow exposing this as a high level user feature for the Web app. 
To keep this simple and with the ongoing backend refactor in mind, the config file was used directly. 