### PR TITLE
Fix broken core on darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 uploads/
 downloads/
+venv*
+virtual*
+.DS_Store*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/MediaProcessor/CMakeLists.txt
+++ b/MediaProcessor/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native -ffast-math -flto")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -march=native")
 
 include(FetchContent)
 set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/_deps") # helps with Docker to resolve

--- a/MediaProcessor/include/ThreadPool.h
+++ b/MediaProcessor/include/ThreadPool.h
@@ -17,7 +17,7 @@ class ThreadPool {
    public:
     ThreadPool(size_t);
     template <class F, class... Args>
-    auto enqueue(F&& f, Args&&... args) -> std::future<typename std::result_of<F(Args...)>::type>;
+    auto enqueue(F&& f, Args&&... args) -> std::future<typename std::invoke_result<F, Args...>::type>;
     ~ThreadPool();
 
    private:
@@ -56,8 +56,8 @@ inline ThreadPool::ThreadPool(size_t threads) : stop(false) {
 // add new work item to the pool
 template <class F, class... Args>
 auto ThreadPool::enqueue(F&& f,
-                         Args&&... args) -> std::future<typename std::result_of<F(Args...)>::type> {
-    using return_type = typename std::result_of<F(Args...)>::type;
+                         Args&&... args) -> std::future<typename std::invoke_result<F, Args...>::type> {
+    using return_type = typename std::invoke_result<F, Args...>::type;
 
     auto task = std::make_shared<std::packaged_task<return_type()> >(
         std::bind(std::forward<F>(f), std::forward<Args>(args)...));
@@ -89,6 +89,7 @@ inline ThreadPool::~ThreadPool() {
 
 /*
     Copyright (c) 2012 Jakob Progsch, Václav Zeman
+    Updated for C++17 and later compatibility by Omer Yusuf Yagci, 2024.
 
     This software is provided 'as-is', without any express or implied
     warranty. In no event will the authors be held liable for any damages

--- a/MediaProcessor/src/Engine.cpp
+++ b/MediaProcessor/src/Engine.cpp
@@ -1,4 +1,4 @@
-#include "MediaProcessor.h"
+#include "Engine.h"
 
 #include <iostream>
 
@@ -9,10 +9,10 @@
 
 namespace MediaProcessor {
 
-MediaProcessor::MediaProcessor(const std::filesystem::path& mediaPath)
+Engine::Engine(const std::filesystem::path& mediaPath)
     : m_mediaPath(std::filesystem::absolute(mediaPath)) {}
 
-bool MediaProcessor::process() {
+bool Engine::processMedia() {
     ConfigManager& configManager = ConfigManager::getInstance();
     if (!configManager.loadConfig("config.json")) {
         std::cerr << "Error: Could not load configuration." << std::endl;
@@ -33,7 +33,7 @@ bool MediaProcessor::process() {
     }
 }
 
-bool MediaProcessor::processAudio() {
+bool Engine::processAudio() {
     AudioProcessor audioProcessor(m_mediaPath, Utils::prepareAudioOutputPath(m_mediaPath));
     if (!audioProcessor.isolateVocals()) {
         std::cerr << "Failed to process audio." << std::endl;
@@ -44,7 +44,7 @@ bool MediaProcessor::processAudio() {
     return true;
 }
 
-bool MediaProcessor::processVideo() {
+bool Engine::processVideo() {
     auto [extractedVocalsPath, processedMediaPath] = Utils::prepareOutputPaths(m_mediaPath);
     AudioProcessor audioProcessor(m_mediaPath, extractedVocalsPath);
 
@@ -63,7 +63,7 @@ bool MediaProcessor::processVideo() {
     return true;
 }
 
-MediaType MediaProcessor::getMediaType() const {
+MediaType Engine::getMediaType() const {
     const std::string command =
         "ffprobe -loglevel error -show_entries stream=codec_type "
         "-of default=noprint_wrappers=1:nokey=1 \"" +

--- a/MediaProcessor/src/Engine.h
+++ b/MediaProcessor/src/Engine.h
@@ -1,5 +1,5 @@
-#ifndef MEDIAPROCESSOR_H
-#define MEDIAPROCESSOR_H
+#ifndef ENGINE_H
+#define ENGINE_H
 
 #include <filesystem>
 
@@ -7,19 +7,22 @@ namespace MediaProcessor {
 
 enum class MediaType { Audio, Video, Unsupported };
 
-class MediaProcessor {
+/**
+ * @brief Media processing engine that supports audio and video files.
+ */
+class Engine {
    public:
-    explicit MediaProcessor(const std::filesystem::path& mediaPath);
+    explicit Engine(const std::filesystem::path& mediaPath);
 
     /**
      * @brief Processes a media file (audio or video) to isolate vocals.
      *
-     * Processes the media file located at m_mediaPath. Processing is dynamically
-     * adjusted by detecting file type, i.e. audio or video.
+     * Processes the media file located at m_mediaPath.
+     * Processing pipeline is selected dynamically by determining media type.
      *
      * @return true if processing was successful, false otherwise.
      */
-    bool process();
+    bool processMedia();
 
    private:
     std::filesystem::path m_mediaPath;
@@ -50,4 +53,4 @@ class MediaProcessor {
 
 }  // namespace MediaProcessor
 
-#endif  // MEDIAPROCESSOR_H
+#endif  // ENGINE_H

--- a/MediaProcessor/src/main.cpp
+++ b/MediaProcessor/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "MediaProcessor.h"
+#include "Engine.h"
 
 using namespace MediaProcessor;
 
@@ -38,8 +38,8 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    MediaProcessor::MediaProcessor processor(argv[1]);
-    if (!processor.process()) {
+    MediaProcessor::Engine engine(argv[1]);
+    if (!engine.processMedia()) {
         std::cerr << "Media processing failed." << std::endl;
         return 1;
     }


### PR DESCRIPTION
This PR addresses compatibility issues on Apple Silicon macOS machines when using Docker to emulate x86_64. The issue arose due to the `libdf.so` being compiled with AVX2 instructions for x86_64, which are apparently not supported by Docker's QEMU-based emulation on these systems. See the related discussion [here](https://github.com/docker/for-mac/issues/6620) for details. 
Unfortunately, the QEMU limitation is still here, and removing this optimization from the library fixed this issue for us.

Additionally few minor updates to core, to fix a deprecation error with clang and a few other warnings.