### PR TITLE
Update GHCR workflow to provide a separate macOS release

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Image
+name: Build and Publish Docker Images
 
 on:
   push:
@@ -18,7 +18,6 @@ jobs:
       id-token: write
 
     steps:
-
       - name: Checkout Repository
         uses: actions/checkout@v3
 
@@ -29,11 +28,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker Image
+      - name: Build Docker Image for Linux (amd64)
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/fast-music-remover:latest .
 
-      - name: Push Docker Image
+      - name: Push Docker Image for Linux (amd64)
         if: github.event_name == 'push'
         run: |
           docker push ghcr.io/${{ github.repository_owner }}/fast-music-remover:latest
+
+      - name: Build Docker Image for macOS (amd64 workaround)
+        run: |
+          docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/fast-music-remover:macos-latest .
+
+      - name: Push Docker Image for macOS (amd64 workaround)
+        if: github.event_name == 'push'
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/fast-music-remover:macos-latest


### PR DESCRIPTION
This PR fixes #84 by providing a separate release for arm macOS machines. 
The underlying problem was determined to be a known (not to us, at the time) limitation of the QEMU-based Docker emulation on these machines. 
See: https://github.com/docker/for-mac/issues/6620 for details with similar issues. 
This completes the work started by #85. 