### PR TITLE
Bug: Fix audio file with cover image treated as video file 

### DIFF
--- a/MediaProcessor/src/Engine.cpp
+++ b/MediaProcessor/src/Engine.cpp
@@ -86,18 +86,26 @@ MediaType Engine::getMediaType() const {
 
 bool Engine::hasValidVideoStream(const nlohmann::json& streamData) const {
     for (const auto& stream : streamData["streams"]) {
-        if (stream["codec_type"] != "video") {
-            continue;
-        }
-        if(!stream.contains("avg_frame_rate")) {
-            continue;
-        }
-
-        if (!hasZeroFrameRate(stream["avg_frame_rate"])) {
+        if(isValidVideoStream(stream)) {
             return true;
         }
     }
     return false;
+}
+
+bool Engine::isValidVideoStream(const nlohmann::json& stream) const {
+    if (stream["codec_type"] != "video") {
+        return false;
+    }
+    if(!stream.contains("avg_frame_rate")) {
+        return false;
+    }
+
+    if (hasZeroFrameRate(stream["avg_frame_rate"])) {
+        return false;
+    }
+
+    return true;
 }
 
 bool Engine::hasValidAudioStream(const nlohmann::json& streamData) const {

--- a/MediaProcessor/src/Engine.h
+++ b/MediaProcessor/src/Engine.h
@@ -52,18 +52,17 @@ class Engine {
     MediaType getMediaType() const;
 
     /**
-     * @brief Checks if the streams contains valid video stream and not static media (i.e. cover image)
-     * 
-     * @param streamData json data of all the streams
+     * @brief Checks if the streams contains a valid video stream.
+     * A valid video stream is one that has an actual duration and is not static media (e.g., a cover image).
      *
      * @return True if the stream is valid video stream. False otherwise.
      */
     bool hasValidVideoStream(const nlohmann::json& streamData) const;
 
+    bool isValidVideoStream(const nlohmann::json& stream) const;
+
     /**
-     * @brief Checks if the streams contains valid audio stream
-     * 
-     * @param streamData json data of all the streams
+     * @brief Checks if the streams contains a valid audio stream
      *
      * @return True if the stream is valid. False otherwise.
      */
@@ -71,8 +70,6 @@ class Engine {
 
     /**
      * @brief Checks if the stream's avg_frame_rate is 0/0
-     * 
-     * @param frameRate the avg_frame_rate field from stream
      *
      * @return True if avg_frame_rate equals to 0/0. False otherwise.
      */


### PR DESCRIPTION
fixes the bug raised in #90 

The `ffprobe` tool is used to check if any stream contains codec_name as mjpeg.

If mjpeg is present, the media is treated as Audio, other media is treated as Video