### PR TITLE
Feature: Add settings validation to `FFmpegConfigManager`

### DIFF
--- a/MediaProcessor/src/FFmpegConfigManager.cpp
+++ b/MediaProcessor/src/FFmpegConfigManager.cpp
@@ -1,7 +1,5 @@
 #include "FFmpegConfigManager.h"
 
-#include <unistd.h>
-
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
@@ -36,14 +34,11 @@ void FFmpegConfigManager::setCodecStrictness(CodecStrictness strictness) {
 }
 
 void FFmpegConfigManager::setInputFilePath(const fs::path inputFilePath) {
-    int read = access((inputFilePath.string().c_str()), R_OK);
-    if (read < 0 && errno == EACCES) {
-        throw std::runtime_error("Insufficient permissions to read input file!");
-    } else if (read < 0) {
-        throw std::runtime_error("Unable to read input file, are you sure it exists?");
-    } else {
-        m_globalSettings.inputFilePath = inputFilePath;
+    fs::perms p = fs::status(inputFilePath).permissions();
+    if ((p & fs::perms::owner_read) != fs::perms::owner_read) {
+        throw std::runtime_error("Error: Permission denied when reading input file");
     }
+    m_globalSettings.inputFilePath = inputFilePath;
 }
 
 void FFmpegConfigManager::setOutputFilePath(const fs::path outputFilePath) {

--- a/MediaProcessor/src/FFmpegConfigManager.cpp
+++ b/MediaProcessor/src/FFmpegConfigManager.cpp
@@ -92,8 +92,9 @@ int FFmpegConfigManager::getAudioChannels() const {
 void FFmpegConfigManager::setVideoCodec(VideoCodec codec) {
     m_videoSettings.codec = codec;
     if (codec != VideoCodec::COPY) {
-        std::cerr << "Warning: Consider setting video codec to COPY if quality or conversion time are "
-                "unacceptable" << std::endl;
+        std::cerr << "Warning: Consider setting the video codec to COPY for higher quality and "
+                     "faster conversion times"
+                  << std::endl;
     }
 }
 

--- a/MediaProcessor/src/FFmpegConfigManager.h
+++ b/MediaProcessor/src/FFmpegConfigManager.h
@@ -7,13 +7,14 @@
 #include <vector>
 
 #include "ConfigManager.h"
+#include "Utils.h"
 
 namespace fs = std::filesystem;
 
 namespace MediaProcessor {
 
 enum class AudioCodec { AAC, MP3, FLAC, OPUS, UNKNOWN };
-enum class VideoCodec { H264, H265, VP8, VP9, UNKNOWN };
+enum class VideoCodec { H264, H265, VP8, VP9, COPY, UNKNOWN };
 enum class CodecStrictness { VERY, STRICT, NORMAL, UNOFFICIAL, EXPERIMENTAL };
 
 /**
@@ -82,7 +83,7 @@ class FFmpegConfigManager {
     struct FFmpegVideoSettings {
         VideoCodec codec;
 
-        FFmpegVideoSettings() : codec(VideoCodec::H264) {}
+        FFmpegVideoSettings() : codec(VideoCodec::COPY) {}
     } m_videoSettings;
 
     // Update Global, Audio, or Video Settings
@@ -94,6 +95,31 @@ class FFmpegConfigManager {
     std::unordered_map<AudioCodec, std::string> m_audioCodecAsString;
     std::unordered_map<VideoCodec, std::string> m_videoCodecAsString;
     std::unordered_map<CodecStrictness, std::string> m_codecStrictnessAsString;
+
+    // Channel # allowed options
+    static constexpr const int AAC_MAX_CHANNELS = 8;
+    static constexpr const int MP3_MAX_CHANNELS = 2;
+    static constexpr const int FLAC_MAX_CHANNELS = 8;
+    static constexpr const int OPUS_MAX_CHANNELS = 8;
+
+    // Sample rate allowed options
+    static constexpr const std::array<int, 13> AAC_SAMPLE_RATES = {
+        7350, 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000};
+    static constexpr const std::array<int, 9> MP3_SAMPLE_RATES = {8000,  12000, 11025, 16000, 24000,
+                                                                  22050, 32000, 44100, 48000};
+    static constexpr const std::array<int, 5> OPUS_SAMPLE_RATES = {8000, 12000, 16000, 24000,
+                                                                   48000};
+    static constexpr const int FLAC_MAX_SAMPLE_RATE = 1048575;
+
+    template <typename T, std::size_t N>
+    void validateOption(const T optionValue, const std::array<T, N>& validOptions);
+
+    template <typename T>
+    void validateOption(const T optionValue, const T optionMax);
+
+    void validateAudio();
+
+    void validateVideo();
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/FFmpegConfigManager.h
+++ b/MediaProcessor/src/FFmpegConfigManager.h
@@ -167,7 +167,7 @@ class FFmpegConfigManager {
     void validateOption(const T optionValue, const std::unordered_set<T>& validOptions);
 
     template <typename T>
-    void validateOption(const T optionValue, const std::pair<T, T> optionMinMax);
+    void validateOption(const T optionValue, const T min, const T max);
 
     void validateAudio();
 };

--- a/MediaProcessor/src/FFmpegConfigManager.h
+++ b/MediaProcessor/src/FFmpegConfigManager.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "ConfigManager.h"
@@ -96,30 +97,79 @@ class FFmpegConfigManager {
     std::unordered_map<VideoCodec, std::string> m_videoCodecAsString;
     std::unordered_map<CodecStrictness, std::string> m_codecStrictnessAsString;
 
-    // Channel # allowed options
-    static constexpr const int AAC_MAX_CHANNELS = 8;
-    static constexpr const int MP3_MAX_CHANNELS = 2;
-    static constexpr const int FLAC_MAX_CHANNELS = 8;
-    static constexpr const int OPUS_MAX_CHANNELS = 8;
+    struct ValidAudioOptions {
+        struct ValidOptionsAAC {
+            inline static const int minChannels = 1;
+            inline static const int maxChannels = 8;
+            inline static const int minBitrate = 96000;
+            inline static const int maxBitrate = 512000;
+            inline static const std::unordered_set<int> sampleRates = {
+                7350,  8000,  11025, 12000, 16000, 22050, 24000,
+                32000, 44100, 48000, 64000, 88200, 96000};
+        } AAC;
 
-    // Sample rate allowed options
-    static constexpr const std::array<int, 13> AAC_SAMPLE_RATES = {
-        7350, 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000};
-    static constexpr const std::array<int, 9> MP3_SAMPLE_RATES = {8000,  12000, 11025, 16000, 24000,
-                                                                  22050, 32000, 44100, 48000};
-    static constexpr const std::array<int, 5> OPUS_SAMPLE_RATES = {8000, 12000, 16000, 24000,
+        struct ValidOptionsMP3 {
+            inline static const int minChannels = 1;
+            inline static const int maxChannels = 2;
+            inline static const int minBitrate = 128000;
+            inline static const int maxBitrate = 320000;
+            inline static const std::unordered_set<int> sampleRates = {
+                8000, 12000, 11025, 16000, 24000, 22050, 32000, 44100, 48000};
+        } MP3;
+
+        struct ValidOptionsFLAC {
+            inline static const int minChannels = 1;
+            inline static const int maxChannels = 8;
+            inline static const int minSampleRate = 0;
+            inline static const int maxSampleRate = 1048575;
+        } FLAC;
+
+        struct ValidOptionsOpus {
+            inline static const int minChannels = 1;
+            inline static const int maxChannels = 8;
+            inline static const int minBitrate = 24000;
+            inline static const int maxBitrate = 512000;
+            inline static const std::unordered_set<int> sampleRates = {8000, 12000, 16000, 24000,
+                                                                       48000};
+        } Opus;
+
+    } inline static const m_validAudioOptions;
+
+    struct FFmpegValidSettingsAAC {
+        inline static const std::pair<int, int> minMaxChannels = {1, 8};
+        inline static const std::pair<int, int> minMaxBitRate = {96000, 512000};
+        inline static const std::unordered_set<int> sampleRates = {
+            7350,  8000,  11025, 12000, 16000, 22050, 24000,
+            32000, 44100, 48000, 64000, 88200, 96000};
+    } m_validSettingsAAC;
+
+    struct FFmpegValidSettingsMP3 {
+        inline static const std::pair<int, int> minMaxChannels = {1, 2};
+        inline static const std::pair<int, int> minMaxBitRate = {128000, 320000};
+        inline static const std::unordered_set<int> sampleRates = {
+            8000, 12000, 11025, 16000, 24000, 22050, 32000, 44100, 48000};
+    } m_validSettingsMP3;
+
+    struct FFmpegValidSettingsFLAC {
+        inline static const std::pair<int, int> minMaxChannels = {1, 8};
+        inline static const std::pair<int, int> minMaxSampleRates = {0, 1048575};
+    } m_validSettingsFLAC;
+
+    struct FFmpegValidSettingsOpus {
+        inline static const std::pair<int, int> minMaxChannels = {1, 8};
+        inline static const std::pair<int, int> minMaxBitRate = {64000, 512000};
+        inline static const std::unordered_set<int> sampleRates = {8000, 12000, 16000, 24000,
                                                                    48000};
-    static constexpr const int FLAC_MAX_SAMPLE_RATE = 1048575;
 
-    template <typename T, std::size_t N>
-    void validateOption(const T optionValue, const std::array<T, N>& validOptions);
+    } m_validSettingsOpus;
 
     template <typename T>
-    void validateOption(const T optionValue, const T optionMax);
+    void validateOption(const T optionValue, const std::unordered_set<T>& validOptions);
+
+    template <typename T>
+    void validateOption(const T optionValue, const std::pair<T, T> optionMinMax);
 
     void validateAudio();
-
-    void validateVideo();
 };
 
 }  // namespace MediaProcessor

--- a/MediaProcessor/src/FFmpegController.cpp
+++ b/MediaProcessor/src/FFmpegController.cpp
@@ -24,8 +24,6 @@ bool FFmpegController::extractAudio() {
 }
 
 std::vector<fs::path> FFmpegController::splitMedia(int numChunks, double overlapDuration) {
-    Utils::ensureDirectoryExists(m_ffmpegConfig.getOutputFilePath());
-
     std::vector<double> chunkStartTimes;
     std::vector<double> chunkDurations;
     std::vector<fs::path> chunkPathCol;


### PR DESCRIPTION
Hi @omeryusufyagci, hope you're doing well!

This PR relates to #56 by adding settings validation for the current FFmpeg options available in `FFmpegConfigManager`. More specifically, it attempts to address issues where the sample rate or number of audio channels could be unacceptable to FFmpeg. I reviewed the codecs rather thoroughly, but I did not consider other audio/video options for this PR primarily because they aren't currently needed/I'm unsure which you'd eventually like to add.

In addition to referencing the current specs for the available codecs (AAC, MP3, FLAC, Opus) I also did some testing with FFmpeg to determine when it continue even when given an option outside the spec. In this way, the config manager should only throw an error when FFmpeg would truly panic, not when it proceeds with its own set of assumptions. I also reviewed cases where FFmpeg could throw an error even though the spec states it is valid (255 Opus channels could require a very complicated rematrix!).

Last, two template functions were added to help streamline the process of adding new options later. These templates address the two primary ways in which FFmpeg conceives of a valid option: either a maximum unsigned integer, or a list of acceptable unsigned integers.